### PR TITLE
Use virtual tree instead of disk to move files to legacy/

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -60,10 +60,10 @@ module.exports = api => {
     const srcFileList = fileList.filter(file => /^src\//.test(file))
     const originals = srcFileList.filter(file => !templates.includes(file) && !/^src\/legacy\//.test(file))
 
-    originals.forEach(file => {
-      const currentPath = api.resolve(file)
-      const newPath = currentPath.replace('/src/', '/src/legacy/')
-      fs.move(currentPath, newPath)
+    originals.forEach(path => {
+      newPath = path.replace('src/', 'src/legacy/')
+      files[newPath] = files[path]
+      delete files[path]
     })
   })
 }

--- a/generator/index.js
+++ b/generator/index.js
@@ -25,7 +25,7 @@ const walk = (p, fileCallback, errCallback) => {
 module.exports = api => {
   api.extendPackage({
     dependencies: {
-      "nuxt": "^1.4.0"
+      "nuxt-edge": "^2.0.0-25506422.d9d2d9e"
     },
     scripts: {
       "dev": "nuxt",


### PR DESCRIPTION
The code in `api.postProcessFiles` doesn't work as written when the plugin is used in a new project (`vue create` instead of `vue add`). As far as I can tell, this is because vue-cli generator plugins execute against a virtual file tree *before* any files are created on disk. So, when creating a new projects, fs.move won't work because the files don't actually exist yet. However, if you manipulate the files object passed to the callback in `api.postProcessFiles`, the changes will be made for a new project.